### PR TITLE
Fix invalid useragents.xml file

### DIFF
--- a/useragents.xml
+++ b/useragents.xml
@@ -781,4 +781,4 @@
 		<useragent description="User-agent strings: www.useragentstring.com" useragent="" appcodename="" appname="" appversion="" platform="" vendor="" vendorsub=""/>
 		<useragent description="User-agent strings: www.webapps-online.com/online-tools/user-agent-strings/dv/" useragent="" appcodename="" appname="" appversion="" platform="" vendor="" vendorsub=""/>
 	</folder>
-</useragentswitcher>xx
+</useragentswitcher>


### PR DESCRIPTION
Remove 2 `x` characters at the end of the useragents.xml file which are causing firefox to not import the list.
